### PR TITLE
FEAT: Add delivery cancel feature with UI and backend support

### DIFF
--- a/handlers/deliveries.handler.php
+++ b/handlers/deliveries.handler.php
@@ -92,3 +92,33 @@ if ($action === 'delete' && $_SERVER['REQUEST_METHOD'] === 'POST') {
     echo json_encode(['success' => $success]);
     exit;
 }
+
+if ($action === 'cancel' && $_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!isset($_POST['delivery_id'])) {
+        header('Content-Type: application/json');
+        echo json_encode(['success' => false, 'error' => 'Missing delivery_id parameter']);
+        exit;
+    }
+
+    // Only update status to 'Cancelled'
+    $delivery_id = $_POST['delivery_id'];
+    $delivery = Deliveries::getById($pdo, $delivery_id);
+    if (!$delivery) {
+        echo json_encode(['success' => false, 'error' => 'Delivery not found']);
+        exit;
+    }
+    
+    // Only allow cancel if status is 'Pending'
+    $status = strtolower($delivery['status']);
+    if ($status !== 'pending' && $status !== 'in transit') {
+        echo json_encode(['success' => false, 'error' => 'Cannot cancel delivery unless it is Pending or In Transit']);
+        exit;
+    }
+    
+    $data = $delivery;
+    $data['status'] = 'Cancelled';
+    $success = Deliveries::updateById($pdo, $delivery_id, $data);
+    header('Content-Type: application/json');
+    echo json_encode(['success' => $success]);
+    exit;
+}

--- a/pages/deliveriesPage/assets/js/deliveries.js
+++ b/pages/deliveriesPage/assets/js/deliveries.js
@@ -1,0 +1,23 @@
+document.addEventListener("DOMContentLoaded", () => {
+  document.body.addEventListener("click", function (e) {
+    if (e.target.classList.contains("cancel-btn")) {
+      const btn = e.target;
+      if (!confirm("Are you sure you want to cancel this delivery?")) return;
+      const deliveryId = btn.getAttribute("data-id");
+      fetch("/handlers/deliveries.handler.php?action=cancel", {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: "delivery_id=" + encodeURIComponent(deliveryId),
+      })
+        .then((res) => res.json())
+        .then((result) => {
+          if (result.success) {
+            window.location.reload();
+          } else {
+            alert("Failed to cancel delivery.");
+          }
+        })
+        .catch(() => alert("Error cancelling delivery."));
+    }
+  });
+});

--- a/pages/deliveriesPage/index.php
+++ b/pages/deliveriesPage/index.php
@@ -66,6 +66,7 @@ renderMainLayout(function () use ($deliveries) { ?>
                             <th>Destination</th>
                             <th>ETA</th>
                             <th>Status</th>
+                            <th>Action</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -79,6 +80,11 @@ renderMainLayout(function () use ($deliveries) { ?>
                                     <td><?= htmlspecialchars($delivery['destination']) ?></td>
                                     <td><?= htmlspecialchars($delivery['delivery_time_estimate']) ?></td>
                                     <td><?= htmlspecialchars($delivery['status']) ?></td>
+                                    <td>
+                                        <?php if (strtolower($delivery['status']) === 'pending' || strtolower($delivery['status']) === 'in transit'): ?>
+                                            <button class="cancel-btn" data-id="<?= htmlspecialchars($delivery['delivery_id']) ?>">Cancel</button>
+                                        <?php endif; ?>
+                                    </td>
                                 </tr>
                             <?php endforeach; ?>
                         <?php else: ?>

--- a/utils/dbSeederPostgresql.util.php
+++ b/utils/dbSeederPostgresql.util.php
@@ -117,7 +117,7 @@ if (is_array($deliveries) && count($deliveries)) {
             ':origin' => $d['origin'],
             ':destination' => $d['destination'],
             ':package_description' => $d['package_description'],
-            ':status' => (isset($sc['status']) && is_bool($sc['status'])) ? $sc['status'] : true,
+            ':status' => $d['status'],
             ':weight_kg' => $d['weight_kg'],
             ':delivery_time_estimate' => $d['delivery_time_estimate'],
         ]);


### PR DESCRIPTION
Introduce a feature that allows users to cancel pending or in-transit deliveries from the deliveries page. Implement backend validation and status updates, along with a user-friendly cancel button in the UI to enhance delivery management.